### PR TITLE
Upgrade master to Java 25

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  JAVA_VERSION_TO_USE: '21'
+  JAVA_VERSION_TO_USE: '25'
   JAVA_DISTRI_TO_USE: 'corretto'
   GITHUB_TOKEN_READ_PACKAGES: ${{ secrets.GH_WORKFLOWS_PAT_READ_PACKAGES }}
   GITHUB_TOKEN_DEPLOY_PACKAGES: ${{ github.token }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  JAVA_VERSION_TO_USE: '21'
+  JAVA_VERSION_TO_USE: '25'
   JAVA_DISTRI_TO_USE: 'corretto'
   GITHUB_TOKEN_READ_PACKAGES: ${{ secrets.GH_WORKFLOWS_PAT_READ_PACKAGES }}
   GITHUB_TOKEN_DEPLOY_PACKAGES: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -407,9 +407,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${compiler.plugin.version}</version>
                     <configuration>
-                        <release>21</release>
-                        <source>21</source>
-                        <target>21</target>
+                        <release>25</release>
+                        <source>25</source>
+                        <target>25</target>
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>
                 </plugin>
@@ -638,7 +638,7 @@
                     <version>${javadoc.plugin.version}</version>
                     <configuration>
                         <charset>UTF-8</charset>
-                        <source>21</source>
+                        <source>25</source>
                         <detectJavaApiLink>false</detectJavaApiLink>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Update the JPAW master branch to run on Java 25.

Changes:
- bump the root POM compiler settings to Java 25
- bump the javadoc plugin source level to Java 25
- update snapshot and release workflows to use JDK 25

Fixes JPAW-16.